### PR TITLE
"#14 Fix missing link from last up block to Conv2D"

### DIFF
--- a/densenet.py
+++ b/densenet.py
@@ -627,10 +627,11 @@ def __create_fcn_dense_net(nb_classes, img_input, include_top, nb_dense_block=5,
             channel, row, col = input_shape
         else:
             row, col, channel = input_shape
-            x = x_up
 
         x = Reshape((row * col, nb_classes))(x)
         x = Activation(activation)(x)
         x = Reshape((row, col, nb_classes))(x)
+    else:
+        x = x_up
 
     return x

--- a/densenet.py
+++ b/densenet.py
@@ -627,6 +627,7 @@ def __create_fcn_dense_net(nb_classes, img_input, include_top, nb_dense_block=5,
             channel, row, col = input_shape
         else:
             row, col, channel = input_shape
+            x = x_up
 
         x = Reshape((row * col, nb_classes))(x)
         x = Activation(activation)(x)


### PR DESCRIPTION
Includes 'x_up' on the upsampling dense blocks allows the 'include_top'
layer to get the full feature map at the end of the upsampling branch.

This commit also changes the 'concatenate' inside __dense_block as the
previous method was failing to run on TensorFlow backend.

This was tested using Keras 2.0.2 and TensorFlow 1.1.0

I was having issues when running the concatenate with your list method and my code works on tf, but I didn't test it with th backend.

Also I double checked that the dimensions make sense by comparing with the Lasagne implementation from Simon Jégou. The only thing that is still weird is that this has fewer connections than the table on their paper suggests. I trained it to find vehicles on a video stream and got very good results, but it's possible that there are still something missing.